### PR TITLE
[EWG] - Make obtaining of Nexus binary idempotent

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,7 @@
 ---
 # tasks file for ansible-nexus
 - name: download Nexus to host
-  local_action: >
-    command wget -N -P "{{nexus_download_dir}}"  http://download.sonatype.com/nexus/oss/{{nexus_package}}
+  local_action: get_url url=http://download.sonatype.com/nexus/oss/{{nexus_package}} dest="{{nexus_download_dir}}/{{nexus_package}}"
   tags: download
   sudo: no
 


### PR DESCRIPTION
Hi,

I noticed the Nexus binary gets downloaded on every invocation of the role. This change makes it idempotent so it only gets downloaded if it doesn't already exist at the download location.

I have tested this in my fork and it seems to work fine, thought I'd submit it in case you're interested in integrating it.

Cheers,

Edd
