### PR TITLE
[EWG] - Can now configure any line in nexus.properties...

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ TODO
 - Change default admin account (admin/admin123)
 
 
-
 Role Variables
 --------------
 
@@ -19,6 +18,12 @@ Role Variables
 - **nexus_installation_dir**: installation prefix that will be used on installation hosts. Defaults to *'/usr/share'*
 - **nexus_work_dir**: working directory, aka sonatype-work
 - **nexus_port**: TCP port
+- **nexus_manage_os_user**: Boolean value which controls whether the nexus o/s user is managed by the Playbook. Defaults to true.
+- **nexus_os_user**: The name of the nexus o/s user to create/ manage when ``nexus_manage_os_user`` is true. Defaults to 'nexus'.
+- **nexus_manage_os_group**: Boolean value which controls whether the nexus o/s group is managed by the Playbook. Defaults to the value of ``nexus_manage_os_user``.
+- **nexus_os_group**: The name of the nexus o/s group to create/ manage when ``nexus_manage_os_group`` is true. Defaults to 'nexus'.
+- **nexus_os_user_shell**: The shell to set for the nexus user. Only effective when when ``nexus_manage_os_user`` is true. Defaults to '/bin/bash'
+- **nexus_properties**: A dict containing key/ value pairs to be written in to ``nexus.properties``. By default this will contain the keys/values specified in ``defaults/main.yml``, however this can be overridden to contain arbitrary keys/values. Note: Ansible does not merge dicts by default so if you provide *any* keys/values then the ones in ``defaults/main.yml`` will not be used and must be re-specified in your dict to be included, (unless you have switched on [hash merging][1] of course). If you re-implement this dict with custom values you _must_ specify a value for the ``nexus-work`` key, even if you stick to the default location. 
 
 Dependencies
 ------------
@@ -44,3 +49,5 @@ Author Information
 
 This playbook is heavily inspired by Alexander Ramos Jardim.
 Any errors are probably my fault.
+
+[1]: http://docs.ansible.com/intro_configuration.html#hash-behaviour

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,10 +5,11 @@ nexus_version: 'latest'
 #nexus_version: '2.10.0-02'
 nexus_package: 'nexus-{{ nexus_version }}-bundle.tar.gz'
 nexus_installation_dir: '/usr/share'
-nexus_working_dir: '/var/nexus'
-nexus_port: 9999
-nexus_create_os_user: true
+nexus_manage_os_user: true
 nexus_os_user: 'nexus'
-nexus_create_os_group: "{{ nexus_create_os_user | bool }}"
+nexus_manage_os_group: "{{ nexus_manage_os_user | bool }}"
 nexus_os_group: 'nexus'
-nexus_os_user_shell: '/usr/sbin/nologin'
+nexus_os_user_shell: '/bin/bash'
+nexus_properties: {'nexus-work': '/var/nexus',
+                   'application-port': 9999,
+                   'nexus-webapp-context-path': '/nexus' }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,12 +7,12 @@
 
 - name: Ensure Nexus o/s group exists
   group: name="{{ nexus_os_group }}" state=present
-  when: nexus_create_os_group
+  when: nexus_manage_os_group
   sudo: true
 
 - name: Ensure Nexus o/s user exists
   user: name="{{ nexus_os_user }}" group="{{ nexus_os_group }}" shell="{{ nexus_os_user_shell }}" state=present
-  when: nexus_create_os_user
+  when: nexus_manage_os_user
   sudo: true
 
 - name: Ensure Nexus installation directory exists
@@ -31,43 +31,42 @@
     group={{ nexus_os_group }}
     mode="0755"
   tags: unpack
+  sudo: true
 
 - name: Check if sonatype working directory exists
   stat: path="{{ nexus_installation_dir }}/sonatype-work"
   register: s_w
 
 - name: Move existing sonatype working directory into specified working dir
-  command: mv "{{ nexus_installation_dir }}/sonatype-work" "{{ nexus_working_dir }}"
+  command: mv "{{ nexus_installation_dir }}/sonatype-work" "{{ nexus_properties['nexus-work'] }}"
   when: s_w.stat.exists
+  sudo: true
 
 - name: Set permissions and ownership on Nexus installation directory
   file:
-    path={{ nexus_installation_dir }}/{{ nexus_package }}
+    path={{ nexus_installation_dir }}/nexus-{{ nexus_version }}
     state="directory"
     owner="{{ nexus_os_user }}"
     group="{{ nexus_os_group }}"
     mode="0755"
     recurse=true
+  sudo: true
 
 - name: Set permissions and ownership on Nexus work directory
   file:
-    path={{ nexus_working_dir }}
+    path={{ nexus_properties['nexus-work'] }}
     state="directory"
     owner="{{ nexus_os_user }}"
     group="{{ nexus_os_group }}"
     mode="0755"
     recurse=true
+  sudo: true
 
-- name: Configure port in nexus.properties
+- name: Configure nexus.properties
   lineinfile:
     dest="{{ nexus_installation_dir }}/nexus-{{ nexus_version }}/conf/nexus.properties"
-    line="application-port={{ nexus_port }}"
-    regexp="application-port=.*"
+    line="{{ item.key }}={{ item.value }}"
+    regexp="{{ item.key }}=.*"
     state=present
-
-- name: Configure workdir in nexus.properties
-  lineinfile:
-    dest="{{ nexus_installation_dir }}/nexus-{{ nexus_version }}/conf/nexus.properties"
-    line="nexus-work={{ nexus_working_dir }}"
-    regexp="nexus-work=.*"
-    state=present
+  with_dict: nexus_properties
+  sudo: true


### PR DESCRIPTION
...by setting the appropriate key in the 'nexus_properties' dict

[2] Also fixed an issue whereby we weren't setting the permissions and ownership on the installation directory correct (we were instead setting the permissions on the downloaded archive).
[3] Also set the nexus user's default shell to '/bin/bash' as it is required to log in as this user to start Nexus.

The behaviour of setting keys and values in `nexus.properties` is now slightly different, because it is now a dict the whole dict gets replaced if the user re-specifies the dict outside of the role defaults. I have updated the README to explain the new behaviour. It felt a little counter-intuitive to me at first as I'm so used to Hiera's hash merging behviour, but given that Ansible doesn't default to dict merging I think it's reasonable. What do you think?
