### PR TITLE
adding symlink for latest nexus_version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,6 +33,9 @@
     mode="0755"
   tags: unpack
 
+- name: Update symlink nexus-latest
+  shell: ln -fs `ls -d {{ nexus_installation_dir }}/nexus-*|tail -1` {{ nexus_installation_dir }}/nexus-latest
+
 - name: Check if sonatype working directory exists
   stat: path="{{ nexus_installation_dir }}/sonatype-work"
   register: s_w


### PR DESCRIPTION
fix for issue #5: adding symlink for latest nexus_version, allows setting port in nexus.properties.